### PR TITLE
Allow more customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,108 @@ void setup() {
 }
 ```
 
-The plugin provides no methods or properties, the above is all it can do.
+You may also set optional parameters.
+
+### Specify by search key
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDEffect-BootGreeting.h>
+
+void setup() {
+  Kaleidoscope.use(&BootGreetingEffect, &LEDOff);
+
+  BootGreetingEffect.search_key = Key_M;
+
+  Kaleidoscope.setup();
+}
+```
+
+### Specify by position
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDEffect-BootGreeting.h>
+
+void setup() {
+  Kaleidoscope.use(&BootGreetingEffect, &LEDOff);
+
+  //Butterfly key
+  BootGreetingEffect.key_col = 7;
+  BootGreetingEffect.key_row = 3;
+
+  Kaleidoscope.setup();
+}
+```
+
+### Specify longer timeout
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDEffect-BootGreeting.h>
+
+void setup() {
+  Kaleidoscope.use(&BootGreetingEffect, &LEDOff);
+
+  //Butterfly key
+  BootGreetingEffect.timeout = 15000;
+
+  Kaleidoscope.setup();
+}
+```
+
+### Specify different color
+```c++
+#include <Kaleidoscope.h>
+#include <Kaleidoscope-LEDEffect-BootGreeting.h>
+
+void setup() {
+  Kaleidoscope.use(&BootGreetingEffect, &LEDOff);
+
+  //Butterfly key
+  BootGreetingEffect.hue = 90;
+
+  Kaleidoscope.setup();
+}
+```
+
+##   Plugin methods
+
+The plugin provides the `BootGreetingEffect` object, with the following methods and
+properties:
+
+### `.search_key`
+
+> Set the key in the current keymap that should be activated with the pulsing
+> LED on startup.  The plugin will search from the top left to the bottom right
+> of the keyboard, row by row, to find this key.  The first matching key will
+> be selected.
+>
+> Defaults to `Key_LEDEffectNext`
+
+### `.key_row`
+
+> This is an optional override to explicitly set the selected key by exact row
+> and column.  This number is 0-indexed, so the top row is 0, the second row is
+> 1, etc.  Must set `.key_col` property for this feature to be enabled.
+
+### `.key_col`
+
+> This is an optional override to explicitly set the selected key by exact row
+> and column.  This number is 0-indexed, so the left-most column is 0, the 
+> second column is 1, etc.  Must set `.key_row` property for this feature to
+> be enabled.
+
+### `.timeout`
+
+> This property specifies the timeout (in milliseconds) for the effect to last.
+> When the keyboard is first connected, the pulsing LED effect will last for
+> this duration before turning off.
+>
+> Defaults to `9200` ms.
+
+### `.hue`
+
+> This property sets the color hue that the LED pulsing effect.
+>
+> The default is `170`, which is a blue color. 
 
 ## Dependencies
 

--- a/src/Kaleidoscope-LEDEffect-BootGreeting.h
+++ b/src/Kaleidoscope-LEDEffect-BootGreeting.h
@@ -24,14 +24,22 @@ namespace kaleidoscope {
 class BootGreetingEffect : public KaleidoscopePlugin {
  public:
   BootGreetingEffect(void) {}
+  BootGreetingEffect(byte, byte);
 
   void begin(void) final;
+  static byte key_row;
+  static byte key_col;
+  static Key search_key;
+  static uint8_t hue;
+  static uint16_t timeout;
 
  private:
   static void loopHook(const bool post_clear);
+  static void findLed(void);
   static bool done_;
   static byte row_;
   static byte col_;
+  static uint16_t start_time;
 };
 }
 


### PR DESCRIPTION
These changes allow for more customization of the boot greeting.  I added functionality to change the color of the effect, the duration, the auto-search key, and allow for specific row / column location.

This change requires a change to the LEDControl/LEDUtils files: https://github.com/keyboardio/Kaleidoscope-LEDControl/pull/19